### PR TITLE
Add permissions for Android 11

### DIFF
--- a/system/etc/permissions/privapp-permissions-org.microG.xml
+++ b/system/etc/permissions/privapp-permissions-org.microG.xml
@@ -47,5 +47,7 @@
         <permission name="android.permission.SUBSTITUTE_NOTIFICATION_APP_NAME" />
         <permission name="android.permission.UPDATE_DEVICE_STATS" />
         <permission name="android.permission.WRITE_SECURE_SETTINGS" />
+        <permission name="android.permission.MANAGE_ROLLBACKS" />
+        <permission name="android.permission.LOADER_USAGE_STATS" />
     </privapp-permissions>
 </permissions>


### PR DESCRIPTION
I had a bootloop with crDroid for Android 11 and the real Phonesky.apk. Turns out these two permissions were missing. I added them and it works for me now.