### PR TITLE
Deny certain critical priv-app permissions to real Play Store

### DIFF
--- a/system/etc/permissions/privapp-permissions-org.microG.xml
+++ b/system/etc/permissions/privapp-permissions-org.microG.xml
@@ -34,13 +34,13 @@
         <permission name="android.permission.INTERACT_ACROSS_USERS" />
         <permission name="android.permission.MANAGE_USERS" />
         <permission name="android.permission.PACKAGE_USAGE_STATS" />
-        <permission name="android.permission.PACKAGE_VERIFICATION_AGENT" />
-        <permission name="android.permission.READ_PRIVILEGED_PHONE_STATE" />
+        <deny-permission name="android.permission.PACKAGE_VERIFICATION_AGENT" />
+        <deny-permission name="android.permission.READ_PRIVILEGED_PHONE_STATE" />
         <permission name="android.permission.READ_RUNTIME_PROFILES" />
         <permission name="android.permission.REAL_GET_TASKS" />
         <permission name="android.permission.REBOOT" />
         <permission name="android.permission.SEND_DEVICE_CUSTOMIZATION_READY" />
-        <permission name="android.permission.SEND_SMS_NO_CONFIRMATION" />
+        <deny-permission name="android.permission.SEND_SMS_NO_CONFIRMATION" />
         <permission name="android.permission.SET_PREFERRED_APPLICATIONS" />
         <permission name="android.permission.START_ACTIVITIES_FROM_BACKGROUND" />
         <permission name="android.permission.STATUS_BAR" />


### PR DESCRIPTION
I've recently found out that Android [gives the ability to deny privileged app permissions](https://source.android.com/devices/tech/config/perms-allowlist?hl=en#customizing-allowlists), so I wanted to use this knowledge to tame down Google Play Store a little bit.
Here are the priv-app permission I denied:
- **SEND_SMS_NO_CONFIRMATION**: I think the reason is obvious. No one wants Google to [send SMS on your behalf to verify your phone number](https://support.google.com/android/answer/7521240).
- **READ_PRIVILEGED_PHONE_STATE**: this gives Play Store the ability to [retrieve the IMEI/MEID and SIM serial on Android 10+](https://source.android.com/devices/tech/config/device-identifiers?hl=en).
- **PACKAGE_VERIFICATION_AGENT**: this permission allows Play Store to [hook into the APK install process to read/analyse the package being installed](https://irq5.io/2014/12/01/android-internals-package-verifiers/) in order to check if it's malicious. It may be a desirable feature for some users, but I don't think that any microG user would like the idea of Play Store having the ability to tell Google which app you are about to sideload.

I did some quick testing after denying these permissions and no Play Store functionality seems to be affected (install, paid app license check, in-app purchase restore).