### PR TITLE
Adjust default-permissions files for "hard restricted" permissions & more

### DIFF
--- a/system/etc/default-permissions/permissions-com.android.vending.xml
+++ b/system/etc/default-permissions/permissions-com.android.vending.xml
@@ -14,7 +14,5 @@
     <exception package="com.android.vending">
         <!-- Signature spoofing -->
         <permission name="android.permission.FAKE_PACKAGE_SIGNATURE" fixed="false"/>
-        <!-- for the real Play Store, as this permission is buggy -->
-        <permission name="android.permission.RECEIVE_SMS" fixed="false"/> 
     </exception>
 </exceptions>

--- a/system/etc/default-permissions/permissions-com.google.android.gms.xml
+++ b/system/etc/default-permissions/permissions-com.google.android.gms.xml
@@ -13,7 +13,7 @@
     <exception package="com.google.android.gms">
         <!-- Phone -->
         <permission name="android.permission.READ_PHONE_STATE" fixed="false"/>
-        <permission name="android.permission.RECEIVE_SMS" fixed="false" />
+        <permission name="android.permission.RECEIVE_SMS" fixed="false" whitelisted="true" />
         <!-- Account -->
         <permission name="android.permission.READ_CONTACTS" fixed="false"/>
         <permission name="android.permission.WRITE_CONTACTS" fixed="false"/>
@@ -21,7 +21,7 @@
         <!-- Location -->
         <permission name="android.permission.ACCESS_FINE_LOCATION" fixed="false"/>
         <permission name="android.permission.ACCESS_COARSE_LOCATION" fixed="false"/>
-        <permission name="org.microg.permission.FORCE_COARSE_LOCATION" fixed="false"/>
+        <permission name="android.permission.ACCESS_BACKGROUND_LOCATION" fixed="false" whitelisted="true" />
         <!-- Storage -->
         <permission name="android.permission.READ_EXTERNAL_STORAGE" fixed="false"/>
         <permission name="android.permission.WRITE_EXTERNAL_STORAGE" fixed="false"/>

--- a/system/etc/permissions/privapp-permissions-org.microG.xml
+++ b/system/etc/permissions/privapp-permissions-org.microG.xml
@@ -3,13 +3,8 @@
     <privapp-permissions package="com.google.android.gms">
         <permission name="android.permission.INSTALL_LOCATION_PROVIDER"/>
         <permission name="android.permission.CHANGE_DEVICE_IDLE_TEMP_WHITELIST"/>
-	<permission name="android.permission.FAKE_PACKAGE_SIGNATURE"/>
-	<permission name="android.permission.UPDATE_APP_OPS_STATS"/>
-    </privapp-permissions>
-    <privapp-permissions package="com.google.android.gsf">
-        <permission name="android.permission.FAKE_PACKAGE_SIGNATURE"/>
-    </privapp-permissions>
-    <privapp-permissions package="org.microg.gms.droidguard">
+	    <permission name="android.permission.FAKE_PACKAGE_SIGNATURE"/>
+	    <permission name="android.permission.UPDATE_APP_OPS_STATS"/>
     </privapp-permissions>
     <!-- For real Play Store; Fake Store will not use all except one (FAKE_PACKAGE_SIGNATURE) of them -->
     <privapp-permissions package="com.android.vending">

--- a/system/etc/sysconfig/org.microG.xml
+++ b/system/etc/sysconfig/org.microG.xml
@@ -19,22 +19,17 @@
     <allow-in-power-save package="com.google.android.gms" />
     <allow-in-data-usage-save package="com.google.android.gms" />
     <allow-unthrottled-location package="com.google.android.gms" />
-    <allow-ignore-location-settings package="com.google.android.gms" />
-    <allow-in-power-save-except-idle package="com.google.android.apps.work.oobconfig" />
-    <allow-in-data-usage-save package="com.google.android.apps.work.oobconfig" />
     <allow-in-power-save-except-idle package="com.google.android.apps.turbo" />
     <allow-implicit-broadcast action="com.google.android.checkin.CHECKIN_COMPLETE" />
     <allow-implicit-broadcast action="com.google.gservices.intent.action.GSERVICES_CHANGED" />
     <allow-implicit-broadcast action="com.google.gservices.intent.action.GSERVICES_OVERRIDE" />
     <allow-implicit-broadcast action="com.google.android.c2dm.intent.RECEIVE" />
-    <allow-in-power-save-except-idle package="com.android.vending" />
     <allow-in-power-save package="com.google.android.volta" />
     <allow-in-power-save package="com.google.android.ims" />
     <allow-in-data-usage-save package="com.google.android.ims" />
     <app-link package="com.android.vending" />
     <system-user-whitelisted-app package="com.android.vending" />
     <system-user-whitelisted-app package="com.google.android.gms" />
-    <system-user-whitelisted-app package="com.google.android.gms.policy_auth" />
     <system-user-blacklisted-app package="com.google.android.googlequicksearchbox" />
     <allow-association target="com.google.android.as" allowed="com.android.systemui" />
     <allow-association target="com.google.android.as" allowed="com.google.android.gms" />


### PR DESCRIPTION
As promised, in this PR I've adjusted the GMS default-permissions XML file to grant and whitelist "hard restricted" permissions (`RECEIVE_SMS` and `ACCESS_BACKGROUND_LOCATION`, see #20 for details). I've also removed `org.microg.permission.FORCE_COARSE_LOCATION` permission from that file since I couldn't find any reference to it in GmsCore manifest (that's probably a legacy leftover).

I've decided to remove `RECEIVE_SMS` altogether from Play Store default-permissions file instead of whitelisting it, since I don't feel very comfortable in granting this permission by default. Also, denying it seems (at least to me) more consistent with what we did in #24 to `SEND_SMS_NO_CONFIRMATION` permission.

I have done also a couple of extra things:
- cleaned up microG priv-app permissions file by removing empty tags/unused permissions
- removed some lines in sysconfig file that seemed a bit eccessive to me, particularly:
  - power save exemption for Play Store, given that it isn't an app that is critical to have running in power save mode
  - the ability for GmsCore to access location even when location is disabled (see [here](https://cs.android.com/android/platform/superproject/+/android-11.0.0_r40:frameworks/base/core/java/com/android/server/SystemConfig.java;l=158)). I don't think microG will ever abuse this on purpose, but I fear that this might be exploited by apps that use microG location services (though I may very well be wrong)
  - a couple of exemptions regarding "Device Setup" app (I don't think this is ever installed on a microG phone)

All these changes have been tested on my Android 10 phone by manually modifying system files in-place.