### PR TITLE
Avoid reinstalling real Play Store + small improvements

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -24,7 +24,6 @@ if $BOOTMODE; then
     fi
 
 else
-    ui_print "- ERROR: Installation via recovery is NOT supported."
-    exit 1
+    abort "- ERROR: Installation via recovery is NOT supported."
 fi
 

--- a/customize.sh
+++ b/customize.sh
@@ -6,6 +6,7 @@ install_phonesky()
 
 if $BOOTMODE; then
 
+    ui_print "- Installing microG GmsCore"
     pm install --dont-kill -g "$MODPATH/system/priv-app/GmsCore/GmsCore.apk"
     pm install --dont-kill "$MODPATH/SigSpoofHelper.apk" 2>/dev/null
     rm -f "$MODPATH/SigSpoofHelper.apk"

--- a/customize.sh
+++ b/customize.sh
@@ -1,18 +1,30 @@
+install_phonesky()
+{
+    pm install --dont-kill "$MODPATH/system/priv-app/Phonesky/Phonesky.apk"
+    pm grant com.android.vending android.permission.FAKE_PACKAGE_SIGNATURE
+}
+
 if $BOOTMODE; then
 
-pm install --dont-kill -g "$MODPATH/system/priv-app/GmsCore/GmsCore.apk"
-pm install --dont-kill "$MODPATH/SigSpoofHelper.apk" 2>/dev/null
-rm -f "$MODPATH/SigSpoofHelper.apk"
-if [ -f /data/adb/Phonesky.apk ]; then
-ui_print "- Installing real Play Store"
-cp /data/adb/Phonesky.apk "$MODPATH/system/priv-app/Phonesky/Phonesky.apk"
-else
-ui_print "- Real Play Store not found, installing Fake Store"
-fi
-pm install --dont-kill "$MODPATH/system/priv-app/Phonesky/Phonesky.apk"
-pm grant com.android.vending android.permission.FAKE_PACKAGE_SIGNATURE
+    pm install --dont-kill -g "$MODPATH/system/priv-app/GmsCore/GmsCore.apk"
+    pm install --dont-kill "$MODPATH/SigSpoofHelper.apk" 2>/dev/null
+    rm -f "$MODPATH/SigSpoofHelper.apk"
+    if [ -f /data/adb/Phonesky.apk ]; then
+        cp /data/adb/Phonesky.apk "$MODPATH/system/priv-app/Phonesky/Phonesky.apk"
+        # If the real Play Store is already installed, don't install it again since
+        # it will result in an error if real Play Store is not patched and has
+        # already auto-updated itself
+        if [ ! $(pm list packages | grep com.android.vending) ]; then
+            ui_print "- Installing real Play Store"
+            install_phonesky
+        fi
+    else
+        ui_print "- Real Play Store not found, installing Fake Store"
+        install_phonesky
+    fi
 
 else
-ui_print "- ERROR: Installation via recovery is NOT supported."
-exit 1
+    ui_print "- ERROR: Installation via recovery is NOT supported."
+    exit 1
 fi
+

--- a/system/etc/sysconfig/org.microG.xml
+++ b/system/etc/sysconfig/org.microG.xml
@@ -31,8 +31,14 @@
     <system-user-whitelisted-app package="com.android.vending" />
     <system-user-whitelisted-app package="com.google.android.gms" />
     <system-user-blacklisted-app package="com.google.android.googlequicksearchbox" />
-    <allow-association target="com.google.android.as" allowed="com.android.systemui" />
-    <allow-association target="com.google.android.as" allowed="com.google.android.gms" />
-    <allow-association target="com.google.android.as" allowed="com.google.android.gsf" />
+
+    <!-- microG UnifiedNlp backends -->
+    <allow-unthrottled-location package="org.microg.nlp.backend.apple" />
+    <allow-unthrottled-location package="org.microg.nlp.backend.ichnaea" />
+    <allow-unthrottled-location package="org.microg.nlp.backend.nominatim" />
+    <allow-unthrottled-location package="org.radiocells.unifiedNlp" />
+    <allow-unthrottled-location package="org.fitchfamily.android.wifi_backend" />
+    <allow-unthrottled-location package="org.fitchfamily.android.gsmlocation" />
+    <allow-unthrottled-location package="org.fitchfamily.android.dejavu" />
 </config>
 


### PR DESCRIPTION
This PR changes the module installation logic to avoid reinstalling the real Play Store APK if it's already installed.
You could ask: why bother? The reason is that those who use FakeGApps (XPosed/LSPosed module) for signature spoofing don't need to patch Play Store for in-app purchases support, since signature spoofing works out of the box for the original APK.
And if you use the original unpatched APK, Play Store will be able to auto-update itself. If an auto-update has already happened and the module tries to install the outdated Phonesky.apk in /data/adb/, an error will occur.

There also other smaller improvements:
- use `abort` command instead of `exit` when installation fails in recovery [as recommended by Magisk docs](https://github.com/topjohnwu/Magisk/blob/master/docs/guides.md#functions)
- remove entries in sysconfig XML regarding "Android System Intelligence" app (a stock Pixel exclusive AFAIK) and replace them with more useful exceptions for microG NLP back-ends (adapted from MinMicroG)